### PR TITLE
fix issue with minute / second in ICAL parser

### DIFF
--- a/Model/Event.php
+++ b/Model/Event.php
@@ -122,6 +122,11 @@ class Event
     {
         $str = $datetime->format('Y-m-d H:i:s');
 
-        return date_parse($str);
+        $date = date_parse($str);
+        $date['min'] = $date['minute'];
+        $date['sec'] = $date['second'];
+        unset($date['minute'], $date['second']);
+
+        return $date;
     }
 }


### PR DESCRIPTION
Hi,

With actual implementation it's impossible to set minute or second for an event.

This is because of a parameters mismatch.
