### PR TITLE
Fix #12, allow Symfony 3.0 and update to PSR-4 namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,12 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.1"
+        "symfony/framework-bundle": "~2.1|~3.0"
     },
     "autoload": {
-        "psr-0": { "BOMO\\IcalBundle": "" },
+        "psr-4": { "BOMO\\IcalBundle\\": "" },
         "files": ["lib/kigkonsult/icalcreator/iCalcreator.class.php"]
     },
-    "target-dir": "BOMO/IcalBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.1.x-dev"


### PR DESCRIPTION
This bundle is compatible with Symfony 3.0, but it doesn't allow it.
This PR fixes it, so we can upgrade.