### PR TITLE
Improve documentation to inform users about changes in 37aa7b7

### DIFF
--- a/Model/Alarm.php
+++ b/Model/Alarm.php
@@ -30,7 +30,7 @@ class Alarm
             break;
 
         default:
-            throw new \InvalidArgumentException('Only [display] options are available');
+            throw new \InvalidArgumentException('Only [DISPLAY] options are available');
             break;
         }
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ public function getIcs()
 
     $alarm = $event->newAlarm();
     $alarm
-        ->setAction('display')
+        ->setAction('DISPLAY')
         ->setDescription($event->getProperty('description'))
         ->setTrigger('-PT2H') //See Dateinterval string format
         ;
@@ -206,7 +206,7 @@ vevent function getEvent();
 ###Alarm
 ```php
 Alarm function __construct(mixed $param);
-this function setAction($action); //Currently, only 'display' action is setted.
+this function setAction($action); //Currently, only 'DISPLAY' action is setted.
 this function setDescription($desc);
 this function setTrigger($trigger);
 valarm function getAlarm();

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,5 @@
+# Upgrade notes
+
+
+## 1.0.6
+- The ```Alarm->setProperty($property)``` no longer accepts ```display```, instead use ```DISPLAY```.


### PR DESCRIPTION
In #11, ```display``` has been changed to ```DISPLAY```, but this has not been changed in the documentation or in the error message.
This PR changes the documentation, adds an UPGRADE.md and updates the error message to inform users about this change.