### PR TITLE
[BUGFIX] VTIMEZONE-component missing

### DIFF
--- a/Model/Calendar.php
+++ b/Model/Calendar.php
@@ -19,6 +19,7 @@ class Calendar
         $this->tz = $tz;
         $this->cal = new \vcalendar();
         $this->cal->setProperty("x-wr-timezone", $tz->getTzid());
+        $this->cal->addComponent($tz->getTimezone());
     }
 
     public function setMethod($method)

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -155,6 +155,8 @@ class Event
         $date['sec'] = $date['second'];
         unset($date['minute'], $date['second']);
 
+        $date['tz'] = 'Z';
+
         return $date;
     }
 }

--- a/Model/Timezone.php
+++ b/Model/Timezone.php
@@ -9,9 +9,9 @@ class Timezone
      */
     private $tz;
     
-    public function __construct(array $config = array())
+    public function __construct(array $config = array(), $timezoneType = FALSE)
     {
-        $this->tz = new \vtimezone($config);
+        $this->tz = new \vtimezone($timezoneType, $config);
     }
 
     public function getTzid()

--- a/Model/Timezone.php
+++ b/Model/Timezone.php
@@ -8,7 +8,18 @@ class Timezone
      * vTimezone object
      */
     private $tz;
-    
+
+    /**
+     * @var \calendarComponent
+     */
+    private $standard;
+
+    /**
+     * @var \calendarComponent
+     */
+    private $daylight;
+
+
     public function __construct(array $config = array(), $timezoneType = FALSE)
     {
         $this->tz = new \vtimezone($timezoneType, $config);
@@ -36,5 +47,80 @@ class Timezone
     public function getTimezone()
     {
         return $this->tz;
+    }
+
+    /**
+     * This function sets the properties for the STANDARD component
+     * in the timezone.
+     *
+     * Configuration example for Europe/Paris:
+     * <pre>
+     * array(
+     *   'dtstart'       => '19710101T030000',
+     *   'tzoffsetto'    => '+0100',
+     *   'tzoffsetfrom'  => '+0200',
+     *   'rrule'         => array(
+     *       'freq'      => 'YEARLY',
+     *       'wkst'      => 'MO',
+     *       'interval'  => 1,
+     *       'bymonth'   => 10,
+     *   ),
+     *   'tzname'        => 'CET'
+     *  )
+     *  </pre>
+     *
+     * @author Florian Steinbauer <florian@acid-design.at>
+     *
+     * @param array $config
+     *
+     * @return Timezone
+     */
+    public function setStandard(array $config = array()){
+
+        $this->standard  = & $this->tz->newComponent( "standard" );
+
+        foreach($config as $prop => $value){
+            $this->standard->setProperty($prop, $value);
+        }
+
+        return $this;
+    }
+
+
+    /**
+     * This function sets the properties for the STANDARD component
+     * in the timezone.
+     *
+     * Configuration example for Europe/Paris:
+     * <pre>
+     * array(
+     *   'dtstart'       => '19710101T030000',
+     *   'tzoffsetto'    => '+0200',
+     *   'tzoffsetfrom'  => '+0100',
+     *   'rrule'         => array(
+     *       'freq'      => 'YEARLY',
+     *       'wkst'      => 'MO',
+     *       'interval'  => 1,
+     *       'bymonth'   => 10,
+     *   ),
+     *   'tzname'        => 'CET'
+     *  )
+     *  </pre>
+     *
+     * @author Florian Steinbauer <florian@acid-design.at>
+     *
+     * @param array $config
+     *
+     * @return Timezone
+     */
+    public function setDaylight(array $config = array()){
+
+        $this->daylight  = & $this->tz->newComponent( "daylight" );
+
+        foreach($config as $prop => $value){
+            $this->daylight->setProperty($prop, $value);
+        }
+
+        return $this;
     }
 }

--- a/Provider/IcsProvider.php
+++ b/Provider/IcsProvider.php
@@ -11,9 +11,9 @@ use BOMO\IcalBundle\Model\Timezone,
 
 class IcsProvider
 {
-    public function createTimezone(array $config = array())
+    public function createTimezone(array $config = array(), $timezoneType = FALSE)
     {
-        return new Timezone($config);
+        return new Timezone($config, $timezoneType);
     }
 
     public function createCalendar(Timezone $tz = null)


### PR DESCRIPTION
In the generated iCal, there was no `VTIMEZONE` component.

This generated following error in Microsoft Outlook 2016:

```
The VEVENT, contains a floating DTSTART. Outlook supports floating time for all-day events only. Double-click to open this item.
```

Now the `VTIMEZONE` component gets added automatically to the calendar.    
Also `$timezoneType` can be passed to the Timezone constructor: `TIMEZONE::construct(array $config = array(), $timezoneType = FALSE)`. This is passed to the underlying `vtimezone` object.

There are no breaking changes in this pull request. 