### PR TITLE
use kigkonsult\iCalcreator namespace

### DIFF
--- a/Model/Alarm.php
+++ b/Model/Alarm.php
@@ -2,6 +2,8 @@
 
 namespace BOMO\IcalBundle\Model;
 
+use kigkonsult\iCalcreator\valarm;
+
 class Alarm
 {
     /**
@@ -11,11 +13,11 @@ class Alarm
 
     public function __construct($object = null)
     {
-        if ($object instanceOf \valarm) {
+        if ($object instanceOf valarm) {
             $this->alarm = $object;
 
         } else {
-            $this->alarm = new \valarm();
+            $this->alarm = new valarm();
 
         }
 

--- a/Model/Calendar.php
+++ b/Model/Calendar.php
@@ -2,6 +2,8 @@
 
 namespace BOMO\IcalBundle\Model;
 
+use kigkonsult\iCalcreator\vcalendar;
+
 class Calendar
 {
     /**
@@ -17,7 +19,7 @@ class Calendar
     public function __construct(Timezone $tz)
     {
         $this->tz = $tz;
-        $this->cal = new \vcalendar();
+        $this->cal = new vcalendar();
         $this->cal->setProperty("x-wr-timezone", $tz->getTzid());
         $this->cal->addComponent($tz->getTimezone());
     }

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -2,6 +2,8 @@
 
 namespace BOMO\IcalBundle\Model;
 
+use kigkonsult\iCalcreator\vevent;
+
 class Event
 {
     /**
@@ -16,10 +18,10 @@ class Event
 
     public function __construct($object = null)
     {
-        if ($object instanceOf \vevent) {
+        if ($object instanceOf vevent) {
             $this->event = $object;
         } else {
-            $this->event = new \vevent();
+            $this->event = new vevent();
         }
     }
 

--- a/Model/Timezone.php
+++ b/Model/Timezone.php
@@ -2,6 +2,8 @@
 
 namespace BOMO\IcalBundle\Model;
 
+use kigkonsult\iCalcreator\vtimezone;
+
 class Timezone
 {
     /**
@@ -22,7 +24,7 @@ class Timezone
 
     public function __construct(array $config = array(), $timezoneType = FALSE)
     {
-        $this->tz = new \vtimezone($timezoneType, $config);
+        $this->tz = new vtimezone($timezoneType, $config);
     }
 
     public function getTzid()


### PR DESCRIPTION
In the current master version of kigkonsult/icalcreator some of the class names that were previously in the root namespace are now namespaced in kigkonsult\iCalcreator.