### PR TITLE
Deleted reference asignation of a function

### DIFF
--- a/Model/Timezone.php
+++ b/Model/Timezone.php
@@ -79,7 +79,7 @@ class Timezone
      */
     public function setStandard(array $config = array()){
 
-        $this->standard  = & $this->tz->newComponent( "standard" );
+        $this->standard  = $this->tz->newComponent( "standard" );
 
         foreach($config as $prop => $value){
             $this->standard->setProperty($prop, $value);
@@ -117,7 +117,7 @@ class Timezone
      */
     public function setDaylight(array $config = array()){
 
-        $this->daylight  = & $this->tz->newComponent( "daylight" );
+        $this->daylight  = $this->tz->newComponent( "daylight" );
 
         foreach($config as $prop => $value){
             $this->daylight->setProperty($prop, $value);


### PR DESCRIPTION
To get a reference from a function, the function must have explicitly setted the & before the name. (See http://php.net/manual/en/language.references.return.php).
As it is not defined in kigkonsult\iCalcreator library, it fails.
