### PR TITLE
use stable release of kigkonsult/icalcreator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.1|~3.0",
-        "kigkonsult/icalcreator": "dev-master"
+        "symfony/framework-bundle": "^2.1|^3.0",
+        "kigkonsult/icalcreator": "^2.24"
     },
     "autoload": {
         "psr-4": { "BOMO\\IcalBundle\\": "" }


### PR DESCRIPTION
[28 days ago](https://github.com/iCalcreator/iCalcreator/releases/tag/v2.24), a stable release of version `2.24` for `kigkonsult/icalcreator` has been tagged. This bundle should now require the stable release instead of `dev-master` in order to not have to use `"minimum-stability": "dev"` and to avoid problems such as #25 (#28).