### PR TITLE
fix kigkonsult

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.1|^3.0",
-        "kigkonsult/icalcreator": "^2.24"
+        "kigkonsult/icalcreator": ">2.24 < 2.25"
     },
     "autoload": {
         "psr-4": { "BOMO\\IcalBundle\\": "" }


### PR DESCRIPTION
Kigkonsult has changed to using uppercase class names from v2.26 without proper versioning...
I fixed it by changing the version requirements.