### PR TITLE
add Symfony 4 compatibility

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,9 +7,9 @@
   <parameters>
     <parameter key="bomo_ical.ics_provider.class">BOMO\IcalBundle\Provider\IcsProvider</parameter>
   </parameters>
-  
+
   <services>
-    <service id="bomo_ical.ics_provider" class="%bomo_ical.ics_provider.class%" />
+    <service id="bomo_ical.ics_provider" class="%bomo_ical.ics_provider.class%" public="true"/>
   </services>
 
 </container>

--- a/Tests/DependencyInjectionTest.php
+++ b/Tests/DependencyInjectionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BOMO\IcalBundle\Tests;
+
+
+use PHPUnit\Framework\TestCase;
+
+class DependencyInjectionTest extends TestCase
+{
+    /**
+     * @return TestKernel
+     */
+    protected function buildKernel()
+    {
+        $kernel = new TestKernel(__DIR__.'/../Resources/config/services.xml');
+        $kernel->boot();
+
+        return $kernel;
+    }
+
+    public function testServicesRegistration()
+    {
+        $kernel = $this->buildKernel();
+        $container = $kernel->getContainer();
+
+        $key = 'bomo_ical.ics_provider';
+        $this->assertTrue($container->has($key), "Service $key doesn't seem to be registered");
+
+        $service = $container->get($key);
+        $this->assertNotNull($service, "Instance of $key should not be null");
+    }
+}

--- a/Tests/PhpunitTest.php
+++ b/Tests/PhpunitTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace BOMO\IcalBundle\Tests;
 
-class PhpunitTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PhpunitTest extends TestCase
 {
     public function testPhpunit()
     {

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BOMO\IcalBundle\Tests;
+
+
+use BOMO\IcalBundle\BOMOIcalBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    protected $servicesDefinitionPath;
+
+    public function __construct($servicesDefinitionPath)
+    {
+        parent::__construct('test', true);
+        $this->servicesDefinitionPath = $servicesDefinitionPath;
+    }
+
+    public function registerBundles()
+    {
+        return array(
+            new FrameworkBundle(),
+            new BOMOIcalBundle(),
+        );
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            $container->loadFromExtension('framework', array(
+                'secret' => 'foo',
+            ));
+        });
+
+        $loader->load($this->servicesDefinitionPath);
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-if (!is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
-    throw new \LogicException('Could not find autoload.php in vendor/. Did you run "composer install --dev"?');
-}
-require $autoloadFile;

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,11 @@
         "branch-alias": {
             "dev-master": "1.1.x-dev"
         }
+    },
+    "require-dev": {
+        "symfony/http-kernel": "^2.0|^3.0|^4.0",
+        "symfony/dependency-injection": "^2.0|^3.0|^4.0",
+        "symfony/config": "^2.0|^3.0|^4.0",
+        "phpunit/phpunit": "^7.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "bomo/ical-bundle",
-    "description": "Create ics url or file for Symfony 2",
+    "description": "Create ics url or file for Symfony 2, 3 and 4",
     "homepage": "http://github.com/BorisMorel/IcalBundle",
     "license": "MIT",
     "authors": [
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "^2.1|^3.0",
+        "symfony/framework-bundle": "^2.1|^3.0|^4.0",
         "kigkonsult/icalcreator": ">2.24 < 2.25"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./Tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true">
     <!-- Les fichiers de tests à lancer -->
     <testsuites>
         <testsuite name="BOMOIcalBundle test suite">
@@ -17,7 +21,6 @@
             <directory>./</directory>
             <exclude>
                 <directory>./Resources</directory>
-                <directory>./Tests</directory>
                 <directory>./vendor</directory>
             </exclude>
         </whitelist>


### PR DESCRIPTION
The service needs to be explicitly set as public to be used in Symfony 3.4 and above, where the services are private by default (https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default).

This adds the `public="true"` attribute on the service definition to fix compatibility with Symfony 3.4 and 4.X. I also added some tests that you can launch with

```composer install && ./vendor/bin/phpunit```

![image](https://user-images.githubusercontent.com/576772/59456439-9878f780-8e16-11e9-8c85-e0c291b3661a.png)
