### PR TITLE
Changed Event to use the TimeZone Informationen from the provided DateTime

### DIFF
--- a/Model/Event.php
+++ b/Model/Event.php
@@ -164,7 +164,7 @@ class Event
         $date['sec'] = $date['second'];
         unset($date['minute'], $date['second']);
 
-        $date['tz'] = 'Z';
+        $date['tz'] = $datetime->format('e');
 
         return $date;
     }


### PR DESCRIPTION
In the issue #39  the "error" is described.
I've changed the behavior in this PR to use the TimeZone Information from the provided DateTime Object. 