### PR TITLE
Fix timezone usage

### DIFF
--- a/Model/Calendar.php
+++ b/Model/Calendar.php
@@ -81,9 +81,9 @@ class Calendar
         return $this->cal;
     }
 
-    public function returnCalendar($uid = null)
+    public function returnCalendar()
     {
-        $str = $this->cal->createCalendar($uid);
+        $str = $this->cal->vtimezonePopulate()->createCalendar();
 
         if (false === mb_check_encoding($str, 'UTF-8')) {
             $str = utf8_encode($str);

--- a/Model/Timezone.php
+++ b/Model/Timezone.php
@@ -2,6 +2,7 @@
 
 namespace BOMO\IcalBundle\Model;
 
+use Kigkonsult\Icalcreator\CalendarComponent;
 use Kigkonsult\Icalcreator\Vtimezone;
 
 class Timezone
@@ -12,19 +13,19 @@ class Timezone
     private $tz;
 
     /**
-     * @var \calendarComponent
+     * @var CalendarComponent
      */
     private $standard;
 
     /**
-     * @var \calendarComponent
+     * @var CalendarComponent
      */
     private $daylight;
 
 
-    public function __construct(array $config = array(), $timezoneType = FALSE)
+    public function __construct(array $config = array())
     {
-        $this->tz = new Vtimezone($timezoneType, $config);
+        $this->tz = new Vtimezone($config);
     }
 
     public function getTzid()

--- a/Provider/IcsProvider.php
+++ b/Provider/IcsProvider.php
@@ -11,9 +11,9 @@ use BOMO\IcalBundle\Model\Timezone,
 
 class IcsProvider
 {
-    public function createTimezone(array $config = array(), $timezoneType = FALSE)
+    public function createTimezone(array $config = array())
     {
-        return new Timezone($config, $timezoneType);
+        return new Timezone($config);
     }
 
     public function createCalendar(Timezone $tz = null, $allowNullTimezone = FALSE)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "^2.1|^3.0|^4.0|^5.0",
-        "kigkonsult/icalcreator": ">=2.26 <3.0"
+        "kigkonsult/icalcreator": ">=2.29.18 <3.0"
     },
     "autoload": {
         "psr-4": { "BOMO\\IcalBundle\\": "" }


### PR DESCRIPTION
In newer versions of the icalcreator library, constructor arguments and other behavior concerning timezones has changed. This PR fixes support for timezones in newer library versions.